### PR TITLE
Fix lgtm.yml for LGTM.com C/C++ analysis

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -1,10 +1,9 @@
 extraction:
   cpp:
-    prepare:
-      packages:
-        - swig
+    after_prepare:
+      - mkdir -p _lgtm_build_dir/CMakeFiles/git-data
+      - echo "lgtm-build-no-sha" > _lgtm_build_dir/CMakeFiles/git-data/head-ref
     configure:
       command:
-        - mkdir build
-        - cd build
+        - cd _lgtm_build_dir
         - cmake ..


### PR DESCRIPTION
The configure/build process expects a Git SHA (or any String, really) in `build_dir/CMakeFiles/git-data-head-ref`. Because of the way LGTM works, this SHA cannot be picked up from the `.git` directory.

This custom `.lgtm.yml` fixes that so the build succeeds. Note that there's no need to install dependencies explicitly; these are [auto-detected by LGTM](https://lgtm.com/blog/how_lgtm_builds_cplusplus).

C/C++ results should appear soon after this PR is merged.